### PR TITLE
Fixing CI by reverting ssh-agent to 0.7.0.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -33,7 +33,7 @@ jobs:
           mkdir -p ~/.ssh
           touch ~/.ssh/known_hosts
           curl -L https://api.github.com/meta | jq -r '.ssh_keys | .[]' | sed -e 's/^/github.com /' >> ~/.ssh/known_hosts
-      - uses: webfactory/ssh-agent@v0.8.0
+      - uses: webfactory/ssh-agent@v0.7.0
         with:
             ssh-private-key: |
                   ${{ secrets.SSH_PRIVATE_KEY_JULIAGENDUNIV }}


### PR DESCRIPTION
CI does not work on version 0.8.0. So I am reverting to 0.7.0 to see if that works. 